### PR TITLE
Implement CRUD operations for Subscription entity

### DIFF
--- a/src/main/java/com/subtracker/api/Subscription/BillingUnit.java
+++ b/src/main/java/com/subtracker/api/Subscription/BillingUnit.java
@@ -1,0 +1,8 @@
+package com.subtracker.api.Subscription;
+
+public enum BillingUnit {
+    DAYS,
+    WEEKS,
+    MONTHS,
+    YEARS;
+}

--- a/src/main/java/com/subtracker/api/Subscription/Subscription.java
+++ b/src/main/java/com/subtracker/api/Subscription/Subscription.java
@@ -9,7 +9,6 @@ import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.util.concurrent.TimeUnit;
 
 @Entity
 @Table(name = "subscription")
@@ -37,7 +36,7 @@ public class Subscription {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private TimeUnit billingUnit;
+    private BillingUnit billingUnit;
 
     @Column(nullable = false)
     private boolean automaticallyRenews;

--- a/src/main/java/com/subtracker/api/Subscription/SubscriptionController.java
+++ b/src/main/java/com/subtracker/api/Subscription/SubscriptionController.java
@@ -16,20 +16,20 @@ public class SubscriptionController {
     private final SubscriptionService subscriptionService;
 
     @GetMapping
-    public ResponseEntity<List<Subscription>> getAll(@AuthenticationPrincipal Users user,
+    public ResponseEntity<List<SubscriptionDTO>> getAll(@AuthenticationPrincipal Users user,
                                                      @RequestParam int contextUserId) {
         return ResponseEntity.ok(subscriptionService.getSubscriptions(user, contextUserId));
     }
 
     @PostMapping
-    public ResponseEntity<Subscription> create(@AuthenticationPrincipal Users user,
+    public ResponseEntity<SubscriptionDTO> create(@AuthenticationPrincipal Users user,
                                                @RequestParam int contextUserId,
                                                @RequestBody Subscription sub) {
         return ResponseEntity.ok(subscriptionService.create(user, contextUserId, sub));
     }
 
     @PutMapping
-    public ResponseEntity<Subscription> update(@AuthenticationPrincipal Users user,
+    public ResponseEntity<SubscriptionDTO> update(@AuthenticationPrincipal Users user,
                                                @RequestParam int contextUserId,
                                                @RequestBody Subscription sub) {
         return ResponseEntity.ok(subscriptionService.update(user, contextUserId, sub));
@@ -44,7 +44,7 @@ public class SubscriptionController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<Subscription> getById(@AuthenticationPrincipal Users user,
+    public ResponseEntity<SubscriptionDTO> getById(@AuthenticationPrincipal Users user,
                                                 @RequestParam int contextUserId,
                                                 @PathVariable Long id) {
         return ResponseEntity.ok(subscriptionService.getById(user, contextUserId, id));

--- a/src/main/java/com/subtracker/api/Subscription/SubscriptionController.java
+++ b/src/main/java/com/subtracker/api/Subscription/SubscriptionController.java
@@ -1,0 +1,52 @@
+package com.subtracker.api.Subscription;
+
+import com.subtracker.api.User.Users;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/subscriptions")
+@RequiredArgsConstructor
+public class SubscriptionController {
+
+    private final SubscriptionService subscriptionService;
+
+    @GetMapping
+    public ResponseEntity<List<Subscription>> getAll(@AuthenticationPrincipal Users user,
+                                                     @RequestParam int contextUserId) {
+        return ResponseEntity.ok(subscriptionService.getSubscriptions(user, contextUserId));
+    }
+
+    @PostMapping
+    public ResponseEntity<Subscription> create(@AuthenticationPrincipal Users user,
+                                               @RequestParam int contextUserId,
+                                               @RequestBody Subscription sub) {
+        return ResponseEntity.ok(subscriptionService.create(user, contextUserId, sub));
+    }
+
+    @PutMapping
+    public ResponseEntity<Subscription> update(@AuthenticationPrincipal Users user,
+                                               @RequestParam int contextUserId,
+                                               @RequestBody Subscription sub) {
+        return ResponseEntity.ok(subscriptionService.update(user, contextUserId, sub));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> delete(@AuthenticationPrincipal Users user,
+                                    @RequestParam int contextUserId,
+                                    @PathVariable Long id) {
+        subscriptionService.delete(user, contextUserId, id);
+        return ResponseEntity.ok("Deleted");
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Subscription> getById(@AuthenticationPrincipal Users user,
+                                                @RequestParam int contextUserId,
+                                                @PathVariable Long id) {
+        return ResponseEntity.ok(subscriptionService.getById(user, contextUserId, id));
+    }
+}

--- a/src/main/java/com/subtracker/api/Subscription/SubscriptionDTO.java
+++ b/src/main/java/com/subtracker/api/Subscription/SubscriptionDTO.java
@@ -12,7 +12,7 @@ public class SubscriptionDTO {
     private BigDecimal price;
     private Currency currency;
     private int billingInterval;
-    private TimeUnit billingUnit;
+    private BillingUnit billingUnit;
     private boolean automaticallyRenews;
     private LocalDate startDate;
     private LocalDate nextPaymentDate;
@@ -22,4 +22,28 @@ public class SubscriptionDTO {
     private String url;
     private String notes;
     private SubscriptionStatus status;
+    private int ownerId;
+
+
+
+    public static SubscriptionDTO fromEntity(Subscription subscription) {
+        SubscriptionDTO dto = new SubscriptionDTO();
+        dto.setId(subscription.getId());
+        dto.setName(subscription.getName());
+        dto.setPrice(subscription.getPrice());
+        dto.setCurrency(subscription.getCurrency());
+        dto.setBillingInterval(subscription.getBillingInterval());
+        dto.setBillingUnit(subscription.getBillingUnit());
+        dto.setAutomaticallyRenews(subscription.isAutomaticallyRenews());
+        dto.setStartDate(subscription.getStartDate());
+        dto.setNextPaymentDate(subscription.getNextPaymentDate());
+        dto.setPaymentMethod(subscription.getPaymentMethod());
+        dto.setPaidBy(subscription.getPaidBy());
+        dto.setCategory(subscription.getCategory());
+        dto.setUrl(subscription.getUrl());
+        dto.setNotes(subscription.getNotes());
+        dto.setStatus(subscription.getStatus());
+        dto.setOwnerId(subscription.getUsers().getUserId());
+        return dto;
+    }
 }

--- a/src/main/java/com/subtracker/api/Subscription/SubscriptionDTO.java
+++ b/src/main/java/com/subtracker/api/Subscription/SubscriptionDTO.java
@@ -1,0 +1,25 @@
+package com.subtracker.api.Subscription;
+
+import lombok.Data;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.concurrent.TimeUnit;
+
+@Data
+public class SubscriptionDTO {
+    private Long id;
+    private String name;
+    private BigDecimal price;
+    private Currency currency;
+    private int billingInterval;
+    private TimeUnit billingUnit;
+    private boolean automaticallyRenews;
+    private LocalDate startDate;
+    private LocalDate nextPaymentDate;
+    private PaymentMethod paymentMethod;
+    private String paidBy;
+    private String category;
+    private String url;
+    private String notes;
+    private SubscriptionStatus status;
+}

--- a/src/main/java/com/subtracker/api/Subscription/SubscriptionRepository.java
+++ b/src/main/java/com/subtracker/api/Subscription/SubscriptionRepository.java
@@ -1,0 +1,10 @@
+package com.subtracker.api.Subscription;
+
+import com.subtracker.api.User.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
+    List<Subscription> findAllByUsers(Users users);
+}

--- a/src/main/java/com/subtracker/api/Subscription/SubscriptionService.java
+++ b/src/main/java/com/subtracker/api/Subscription/SubscriptionService.java
@@ -1,0 +1,98 @@
+package com.subtracker.api.Subscription;
+
+import com.subtracker.api.User.Role;
+import com.subtracker.api.User.Users;
+import com.subtracker.api.UserPermissions.UserPermissions;
+import com.subtracker.api.UserPermissions.UserPermissionsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SubscriptionService {
+    private final SubscriptionRepository subscriptionRepository;
+    private final UserPermissionsRepository permissionsRepository;
+
+    public Users resolveContextUser(Users currentUser, int contextUserId) {
+        if (currentUser.getUserId() == contextUserId) return currentUser;
+
+        UserPermissions permission = permissionsRepository
+                .findByGuestUserIdAndOwnerUserId(currentUser.getUserId(), contextUserId)
+                .orElseThrow(() -> new SecurityException("No access to this context"));
+
+        if (permission.getPermission() == Role.GUEST_RO || permission.getPermission() == Role.GUEST_RW) {
+            return permission.getOwner();
+        }
+
+        throw new SecurityException("Insufficient permission for this context");
+    }
+
+    public List<Subscription> getSubscriptions(Users currentUser, int contextUserId) {
+        Users contextUser = resolveContextUser(currentUser, contextUserId);
+        return subscriptionRepository.findAllByUsers(contextUser);
+    }
+
+    public Subscription create(Users currentUser, int contextUserId, Subscription sub) {
+        Users contextUser = resolveContextUser(currentUser, contextUserId);
+
+        if (currentUser.getUserId() != contextUserId &&
+                !hasWritePermission(currentUser, contextUserId)) {
+            throw new SecurityException("Write access denied");
+        }
+
+        sub.setUsers(contextUser);
+        return subscriptionRepository.save(sub);
+    }
+
+    public Subscription update(Users currentUser, int contextUserId, Subscription updated) {
+        Subscription existing = subscriptionRepository.findById(updated.getId())
+                .orElseThrow(() -> new IllegalArgumentException("Subscription not found"));
+
+        if (existing.getUsers().getUserId() != contextUserId) {
+            throw new SecurityException("Subscription does not belong to specified context");
+        }
+
+        if (currentUser.getUserId() != contextUserId &&
+                !hasWritePermission(currentUser, contextUserId)) {
+            throw new SecurityException("Write access denied");
+        }
+
+        updated.setUsers(existing.getUsers());
+        return subscriptionRepository.save(updated);
+    }
+
+    public void delete(Users currentUser, int contextUserId, Long id) {
+        Subscription existing = subscriptionRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Not found"));
+
+        if (existing.getUsers().getUserId() != contextUserId) {
+            throw new SecurityException("Subscription does not belong to specified context");
+        }
+
+        if (currentUser.getUserId() != contextUserId &&
+                !hasWritePermission(currentUser, contextUserId)) {
+            throw new SecurityException("Write access denied");
+        }
+
+        subscriptionRepository.delete(existing);
+    }
+
+    private boolean hasWritePermission(Users guest, int ownerId) {
+        return permissionsRepository.findByGuestUserIdAndOwnerUserId(guest.getUserId(), ownerId)
+                .map(p -> p.getPermission() == Role.GUEST_RW)
+                .orElse(false);
+    }
+
+    public Subscription getById(Users currentUser, int contextUserId, Long id) {
+        Subscription subscription = subscriptionRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Subscription not found"));
+
+        if (subscription.getUsers().getUserId() != contextUserId) {
+            throw new SecurityException("Subscription does not belong to specified context");
+        }
+
+        return subscription;
+    }
+}

--- a/src/main/java/com/subtracker/api/Subscription/SubscriptionService.java
+++ b/src/main/java/com/subtracker/api/Subscription/SubscriptionService.java
@@ -29,12 +29,15 @@ public class SubscriptionService {
         throw new SecurityException("Insufficient permission for this context");
     }
 
-    public List<Subscription> getSubscriptions(Users currentUser, int contextUserId) {
+    public List<SubscriptionDTO> getSubscriptions(Users currentUser, int contextUserId) {
         Users contextUser = resolveContextUser(currentUser, contextUserId);
-        return subscriptionRepository.findAllByUsers(contextUser);
+        return subscriptionRepository.findAllByUsers(contextUser)
+                .stream()
+                .map(SubscriptionDTO::fromEntity)
+                .toList();
     }
 
-    public Subscription create(Users currentUser, int contextUserId, Subscription sub) {
+    public SubscriptionDTO create(Users currentUser, int contextUserId, Subscription sub) {
         Users contextUser = resolveContextUser(currentUser, contextUserId);
 
         if (currentUser.getUserId() != contextUserId &&
@@ -43,10 +46,11 @@ public class SubscriptionService {
         }
 
         sub.setUsers(contextUser);
-        return subscriptionRepository.save(sub);
+        subscriptionRepository.save(sub);
+        return SubscriptionDTO.fromEntity(sub);
     }
 
-    public Subscription update(Users currentUser, int contextUserId, Subscription updated) {
+    public SubscriptionDTO update(Users currentUser, int contextUserId, Subscription updated) {
         Subscription existing = subscriptionRepository.findById(updated.getId())
                 .orElseThrow(() -> new IllegalArgumentException("Subscription not found"));
 
@@ -60,7 +64,8 @@ public class SubscriptionService {
         }
 
         updated.setUsers(existing.getUsers());
-        return subscriptionRepository.save(updated);
+        subscriptionRepository.save(updated);
+        return SubscriptionDTO.fromEntity(updated);
     }
 
     public void delete(Users currentUser, int contextUserId, Long id) {
@@ -85,7 +90,7 @@ public class SubscriptionService {
                 .orElse(false);
     }
 
-    public Subscription getById(Users currentUser, int contextUserId, Long id) {
+    public SubscriptionDTO getById(Users currentUser, int contextUserId, Long id) {
         Subscription subscription = subscriptionRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Subscription not found"));
 
@@ -93,6 +98,6 @@ public class SubscriptionService {
             throw new SecurityException("Subscription does not belong to specified context");
         }
 
-        return subscription;
+        return SubscriptionDTO.fromEntity(subscription);
     }
 }


### PR DESCRIPTION
I implemented all the crud operations for the Subscription entity, each requiring contextUseId because of the contextual roles and permissions
- GET /subscriptions – Get all (by context)
- GET /subscriptions/{id} – Get by ID
- POST /subscriptions – Create (OWNER, GUEST_RW)
- PUT /subscriptions – Update (OWNER, GUEST_RW)
- DELETE /subscriptions/{id} – Delete (OWNER, GUEST_RW)